### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name" : "Apache::LogFormat",
+  "license" : "Artistic-2.0",
   "source-url" : "git://github.com/lestrrat/p6-Apache-LogFormat.git",
   "perl" : "6",
   "build-depends" : [ ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license